### PR TITLE
Upgrade dependency jboss-interceptors-api from 1.0.0.Beta1 to 1.0.0.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,7 +51,7 @@
       -->
       <jsf.api.version>1.2_13</jsf.api.version>
       <jaxws.api.version>2.1</jaxws.api.version>
-      <interceptor.api.version>1.0.0.Beta1</interceptor.api.version>
+      <interceptor.api.version>1.0.0.Final</interceptor.api.version>
    </properties>
 
    <dependencyManagement>


### PR DESCRIPTION
in sync with JBoss AS 7.0.2

https://issues.jboss.org/browse/WELD-1064
