### PR TITLE
WELD-364 SessionObjectReference - minor javadoc fix

### DIFF
--- a/weld-spi/src/main/java/org/jboss/weld/ejb/api/SessionObjectReference.java
+++ b/weld-spi/src/main/java/org/jboss/weld/ejb/api/SessionObjectReference.java
@@ -34,7 +34,7 @@ public interface SessionObjectReference extends Serializable {
      * @param businessInterfaceType the type of the business interface
      * @return a reference
      *
-     * @throws IllegalStateException if the business interface is not a local business interface of the session bean
+     * @throws IllegalStateException if the business interface is not a business interface of the session bean
      * @throws NoSuchEJBException if the session object has already been removed
      */
     <S> S getBusinessObject(Class<S> businessInterfaceType);


### PR DESCRIPTION
- getBusinessObject() may be also used for remote interfaces
