### PR TITLE
WELD-2149 use JDK 9 aware parent and build config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-parent</artifactId>
-        <version>33</version>
+        <version>34</version>
     </parent>
    
     <prerequisites>
@@ -81,7 +81,7 @@
 
     <properties>
         <javadoc.doclint>-Xdoclint</javadoc.doclint>
-        <build.config.version>9</build.config.version>
+        <build.config.version>10</build.config.version>
 
         <atinject.api.version>1</atinject.api.version>
         <cdi.api.version>1.2</cdi.api.version>


### PR DESCRIPTION
Weld parent and build config were both updated to be JDK 9 aware as a part of WELD-2149.
We need but use them in 2.4 branch in order to avoid checkstyle plugin failures in JDK 9.

Weld core has to be updated to make use to API which includes this commit.