### PR TITLE
WELD-2598 Switch to Jakarta EE artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,35 +100,35 @@
         <!-- Might be used to override the version declared in weld-parent -->
         <!-- build.config.version>10-SNAPSHOT</build.config.version -->
 
-        <atinject.api.version>1</atinject.api.version>
-        <cdi.api.version>2.0.SP1</cdi.api.version>
-        <ejb.api.version>1.0.0.Final</ejb.api.version>
-        <jpa.api.version>2.2</jpa.api.version>
-        <validation.api.version>2.0.1.Final</validation.api.version>
-        <jboss.spec.annotation.version>1.0.0.Final</jboss.spec.annotation.version>
-        <jboss.spec.servlet.version>1.0.0.Final</jboss.spec.servlet.version>
-        <jboss.spec.jaxrs.version>1.0.2.Final</jboss.spec.jaxrs.version>
-        <jta.api.version>1.0.0.Final</jta.api.version>
-        <interceptor.api.version>1.0.0.Final</interceptor.api.version>
+        <atinject.api.version>1.0</atinject.api.version>
+        <cdi.api.version>2.0.2</cdi.api.version>
+        <ejb.api.version>2.0.0.Final</ejb.api.version>
+        <jpa.api.version>2.2.3</jpa.api.version>
+        <validation.api.version>2.0.2</validation.api.version>
+        <jboss.spec.annotation.version>2.0.1.Final</jboss.spec.annotation.version>
+        <jboss.spec.servlet.version>2.0.0.Final</jboss.spec.servlet.version>
+        <jboss.spec.jaxrs.version>2.0.1.Final</jboss.spec.jaxrs.version>
+        <jta.api.version>2.0.0.Final</jta.api.version>
+        <interceptor.api.version>2.0.0.Final</interceptor.api.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jpa.api.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
                 <version>${validation.api.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
                 <version>${atinject.api.version}</version>
             </dependency>
 
@@ -140,7 +140,7 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.transaction</groupId>
-                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                <artifactId>jboss-transaction-api_1.3_spec</artifactId>
                 <version>${jta.api.version}</version>
             </dependency>
 
@@ -175,17 +175,17 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${cdi.api.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.el</groupId>
-                        <artifactId>javax.el-api</artifactId>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.interceptor</groupId>
-                        <artifactId>javax.interceptor-api</artifactId>
+                        <groupId>jakarta.interceptor</groupId>
+                        <artifactId>jakarta.interceptor-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/weld-spi/pom.xml
+++ b/weld-spi/pom.xml
@@ -26,8 +26,8 @@
       </dependency>
 
       <dependency>
-          <groupId>javax.persistence</groupId>
-          <artifactId>javax.persistence-api</artifactId>
+          <groupId>jakarta.persistence</groupId>
+          <artifactId>jakarta.persistence-api</artifactId>
           <optional>true</optional>
       </dependency>
 
@@ -40,7 +40,7 @@
 
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.3_spec</artifactId>
          <optional>true</optional>
       </dependency>
 
@@ -51,8 +51,8 @@
       </dependency>
 
       <dependency>
-         <groupId>javax.validation</groupId>
-         <artifactId>validation-api</artifactId>
+         <groupId>jakarta.validation</groupId>
+         <artifactId>jakarta.validation-api</artifactId>
          <optional>true</optional>
       </dependency>
 

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -21,8 +21,8 @@
    <dependencies>
 
       <dependency>
-         <groupId>javax.enterprise</groupId>
-         <artifactId>cdi-api</artifactId>
+         <groupId>jakarta.enterprise</groupId>
+         <artifactId>jakarta.enterprise.cdi-api</artifactId>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The API bits converted into Jakarta deps.

Fun fact: `org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec` is nowhere to be found on GH ([our fork has only 1.2 version](https://github.com/jboss/jboss-transaction-api_spec)), yet it apparently exists *somewhere*...
Will raise this on wfly-dev list to see if anyone knows.