### PR TITLE
Add JBoss repository for plugin downloads (needed for compiler plugin).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,4 +207,17 @@
         <url>scm:git:git@github.com:weld/api.git</url>
         <tag>HEAD</tag>
     </scm>
+
+    <!-- Needed to download org.apache.maven.plugins:maven-compiler-plugin:jar:3.8.0-jboss-2 -->
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
I accidentally broke the SP3 build because I switched to JBoss version of compiler plugin and the project doesn't declare that repo whereas my local settings had it. My bad; this should fix it.