### PR TITLE
Switch default branch to 5.x, update CDI API to 4.0.0.Alpha1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
    <groupId>org.jboss.weld</groupId>
    <artifactId>weld-api-bom</artifactId>
    <packaging>pom</packaging>
-   <version>4.0-SNAPSHOT</version>
+   <version>5.0-SNAPSHOT</version>
 
    <name>Weld APIs BOM</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 
         <annotation.api.version>2.0.0</annotation.api.version>
         <atinject.api.version>2.0.0</atinject.api.version>
-        <cdi.api.version>3.0.0</cdi.api.version>
+        <cdi.api.version>4.0.0.Alpha1</cdi.api.version>
         <ejb.api.version>4.0.0</ejb.api.version>
         <jaxrs.api.version>3.0.0</jaxrs.api.version>
         <jpa.api.version>3.0.0</jpa.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>weld-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.0-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.jboss.weld</groupId>

--- a/weld-spi/pom.xml
+++ b/weld-spi/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <artifactId>weld-api-parent</artifactId>
       <groupId>org.jboss.weld</groupId>
-      <version>4.0-SNAPSHOT</version>
+      <version>5.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <artifactId>weld-api-parent</artifactId>
       <groupId>org.jboss.weld</groupId>
-      <version>4.0-SNAPSHOT</version>
+      <version>5.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Weld API for 4.x is now under this branch - https://github.com/weld/api/tree/4.0

We will need to cut an Alpha release from Weld API so that we can update core and accommodate pending PRs.