### PR TITLE
WELD-2685 Deprecate previous WeldInstance.Handler methods in favor of new CDI API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 
         <annotation.api.version>2.0.0</annotation.api.version>
         <atinject.api.version>2.0.0</atinject.api.version>
-        <cdi.api.version>4.0.0.Alpha3</cdi.api.version>
+        <cdi.api.version>4.0.0.Beta1</cdi.api.version>
         <ejb.api.version>4.0.0</ejb.api.version>
         <jaxrs.api.version>3.0.0</jaxrs.api.version>
         <jpa.api.version>3.0.0</jpa.api.version>

--- a/weld/src/main/java/org/jboss/weld/inject/WeldInstance.java
+++ b/weld/src/main/java/org/jboss/weld/inject/WeldInstance.java
@@ -63,6 +63,9 @@ import jakarta.enterprise.util.TypeLiteral;
 public interface WeldInstance<T> extends Instance<T> {
 
     /**
+     * This method is deprecated as a similar functioning method exists in CDI 4.0 and newer.
+     * Users should instead use {@link Instance#getHandle()}.
+     *
      * Obtains an initialized contextual reference handler for the bean that has the required type and required qualifiers and is eligible for injection.
      *
      * <p>
@@ -73,9 +76,13 @@ public interface WeldInstance<T> extends Instance<T> {
      * @throws UnsatisfiedResolutionException if there is no bean with given type and qualifiers
      * @throws AmbiguousResolutionException if there is more than one bean given type and qualifiers
      */
+    @Deprecated
     Handler<T> getHandler();
 
     /**
+     * This method is deprecated as a similar functioning method exists in CDI 4.0 and newer.
+     * Users should instead use {@link Instance#handles()}.
+     *
      * Allows to iterate over contextual reference handlers for all the beans that have the required type and required qualifiers and are eligible
      * for injection.
      *
@@ -85,17 +92,24 @@ public interface WeldInstance<T> extends Instance<T> {
      *
      * @return a new iterable
      */
+    @Deprecated
     Iterable<Handler<T>> handlers();
 
     /**
+     * This method is deprecated as a similar functioning method exists in CDI 4.0 and newer.
+     * Users should instead use {@link Instance#handlesStream()}.
      *
      * @return a new stream of contextual reference handlers
      */
-    default Stream<Handler<T>> handlersStream() {
+    @Deprecated
+    default Stream<? extends Handler<T>> handlersStream() {
         return StreamSupport.stream(handlers().spliterator(), false);
     }
 
     /**
+     * This method is deprecated in favor of {@link WeldInstance#getHandlePriorityComparator()} which operates on
+     * a non-deprecated {@link Instance.Handle} interface.
+     *
      * The returned comparator sorts handlers by priority in descending order.
      * <ul>
      * <li>A class-based bean whose annotated type has {@code jakarta.annotation.Priority} has the priority of value {@code jakarta.annotation.Priority#value()}</li>
@@ -105,7 +119,20 @@ public interface WeldInstance<T> extends Instance<T> {
      *
      * @return a comparator instance
      */
+    @Deprecated
     Comparator<Handler<?>> getPriorityComparator();
+
+    /**
+     * The returned comparator sorts handles by priority in descending order.
+     * <ul>
+     * <li>A class-based bean whose annotated type has {@code jakarta.annotation.Priority} has the priority of value {@code jakarta.annotation.Priority#value()}</li>
+     * <li>A custom bean which implements {@link Prioritized} has the priority of value {@link Prioritized#getPriority()}</li>
+     * <li>Any other bean has the priority of value 0</li>
+     * </ul>
+     *
+     * @return a comparator instance
+     */
+    Comparator<Handle<?>> getHandlePriorityComparator();
 
     @Override
     WeldInstance<T> select(Annotation... qualifiers);
@@ -134,6 +161,10 @@ public interface WeldInstance<T> extends Instance<T> {
     <X> WeldInstance<X> select(Type subtype, Annotation... qualifiers);
 
     /**
+     * This interface is deprecated.
+     * CDI 4.0 introduced {@link Instance.Handle} interface that offers the same functionality and can be used in place
+     * of Weld specific {@link WeldInstance.Handler}.
+     *
      * This interface represents a contextual reference handler.
      * <p>
      * Allows to inspect the metadata of the relevant bean and also to destroy the underlying contextual instance.
@@ -142,7 +173,8 @@ public interface WeldInstance<T> extends Instance<T> {
      * @author Martin Kouba
      * @param <T> the required bean type
      */
-    interface Handler<T> extends AutoCloseable {
+    @Deprecated
+    interface Handler<T> extends Handle<T> {
 
         /**
          * The contextual reference is obtained lazily, i.e. when first needed.
@@ -157,7 +189,7 @@ public interface WeldInstance<T> extends Instance<T> {
          *
          * @return the bean metadata
          */
-        Bean<?> getBean();
+        Bean<T> getBean();
 
         /**
          * Destroy the contextual instance.


### PR DESCRIPTION
Also adds a new method for comparator based on `Handle` interface.
And updated CDI API to latest release.