### PR TITLE
WELD-2728 Support the lookup attribute of jakarta.annotation.Resource

### DIFF
--- a/weld-spi/src/main/java/org/jboss/weld/injection/spi/helpers/AbstractResourceServices.java
+++ b/weld-spi/src/main/java/org/jboss/weld/injection/spi/helpers/AbstractResourceServices.java
@@ -83,6 +83,11 @@ public abstract class AbstractResourceServices implements Service, ResourceInjec
 
     protected String getResourceName(InjectionPoint injectionPoint) {
         Resource resource = getResourceAnnotation(injectionPoint);
+
+        String lookup = resource.lookup();
+        if (!lookup.equals("")) {
+            return lookup;
+        }
         String mappedName = resource.mappedName();
         if (!mappedName.equals("")) {
             return mappedName;


### PR DESCRIPTION
Lookup is the preferred attribute to use for the @Resource, but Weld didn't support it natively.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>