### PR TITLE
WELD-2732 Support setter method for @Resource annotated methods

### DIFF
--- a/weld-spi/src/main/java/org/jboss/weld/injection/spi/helpers/AbstractResourceServices.java
+++ b/weld-spi/src/main/java/org/jboss/weld/injection/spi/helpers/AbstractResourceServices.java
@@ -35,9 +35,6 @@ import org.jboss.weld.injection.spi.ResourceReferenceFactory;
 public abstract class AbstractResourceServices implements Service, ResourceInjectionServices {
     private static final String RESOURCE_LOOKUP_PREFIX = "java:comp/env";
 
-    // because checkstyle magic numbers
-    private static final int GET_PREFIX_LENGTH = "get".length();
-
     public Object resolveResource(InjectionPoint injectionPoint) {
         if (getResourceAnnotation(injectionPoint) == null) {
             throw new IllegalArgumentException("No @Resource annotation found on injection point " + injectionPoint);
@@ -114,8 +111,11 @@ public abstract class AbstractResourceServices implements Service, ResourceInjec
 
     public static String getPropertyName(Method method) {
         String methodName = method.getName();
-        if (methodName.matches("^(get).*") && method.getParameterTypes().length == 0) {
-            return Introspector.decapitalize(methodName.substring(GET_PREFIX_LENGTH));
+
+        if (methodName.matches("^(set).*") && method.getParameterTypes().length == 1) {
+            return Introspector.decapitalize(methodName.substring(3));
+        } else if (methodName.matches("^(get).*") && method.getParameterTypes().length == 0) {
+            return Introspector.decapitalize(methodName.substring(3));
         } else if (methodName.matches("^(is).*") && method.getParameterTypes().length == 0) {
             return Introspector.decapitalize(methodName.substring(2));
         } else {


### PR DESCRIPTION
With this PR, methods like the following are supported:

```java
    @Resource
    public void setUt(UserTransaction userTransaction) {
      this.userTransaction = userTransaction;
    }
```

Actually, it stands to reason that setter methods should have been the primary supported method to begin with, given the code on line 45:

```java
 if (injectionPoint.getMember() instanceof Method
                && ((Method) injectionPoint.getMember()).getParameterTypes().length != 1) {
            throw new IllegalArgumentException(
                    "Injection point represents a method which doesn't follow JavaBean conventions (must have exactly one parameter) "
                            + injectionPoint);
        }
```

It throws if the number of parameters is not exactly 1, which is the case of a getter method. The setter method indeed has exactly 1 parameter.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>