### PR TITLE
Swap CI to JDK 17 minimum

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,9 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - { name: "11",
-              java-version: 11,
-          }
           - {
             name: "17",
             java-version: 17,


### PR DESCRIPTION
Similar to the core repository, we need to set min JDK to 17.
Some of the EE deps are build in that way already.