### PR TITLE
 Add missing documents to the repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-## Weld Community Code of Conduct v1.0
+## Weld Community Code of Conduct v1.1
 
 ### Contributor Code of Conduct
 
@@ -18,24 +18,25 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses, without explicit permission
-* Other unethical or unprofessional conduct.
+* Publishing other’s private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are not
-aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
-commit themselves to fairly and consistently applying these principles to every aspect
-of managing this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these
+principles to every aspect of managing this project. Project maintainers who do not follow or enforce the
+Code of Conduct may be permanently removed from the project team.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
-contacting the Weld project lead, Matej Novotny <manovotn@redhat.com>.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing
+the project or its community.
 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Weld project
+lead, Matej Novotny <manovotn@ibm.com>.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
+of an incident.
 
-This Code of Conduct is adapted from the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) which is 
-adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 1.2.0, available at
-http://contributor-covenant.org/version/1/2/0/
+This Code of Conduct is adapted from the Contributor Covenant, version 1.3.0, available at 
+https://www.contributor-covenant.org/version/1/3/0/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing Guide
+
+**First of all, thank you for taking the time to contribute to Weld!**
+
+Below are some basics such as building the project, pull request standards and issue tracking.  
+Please read them before making your contribution and try to adhere to them - it will make it a lot easier for us maintainers to accept your contribution.
+
+### Building and Testing
+
+Weld projects use Java and Maven; building them is as easy as running:
+
+```
+mvn clean install
+```
+
+The above command will build the whole project on the branch you checked out as well as execute tests for each module.   
+Note that this will not execute all the tests; in-container tests - for example tests against actual WildFly server - require some extra setup. However, creating a pull request will trigger a CI run that includes all the tests applicable for given branch.
+
+Alternatively, if you want a faster build, you can skip the testing part by running the following command:
+
+```
+mvn clean install -DskipTests
+```
+
+### Code Formatting
+
+All Weld projects that inherit from [Weld Parent](https://github.com/weld/parent/blob/56/pom.xml#L610-L650) will also bring in a Maven formatter plugin and import statement sorter.  
+Triggering a build of the project should automatically format the code as well as imports in Java classes.  
+The set of rules is borrowed from Quarkus IDE config artifact, which can be found [here](https://github.com/quarkusio/quarkus/tree/3.16.1/independent-projects/ide-config/src/main/resources).
+
+### Tracking Your Contributions
+
+Every enhancement or fix should have a tracking issue.  
+Not only does it help create release notes, keep track of what has been done or while searching for similar issues, but it also allows you to explain what/how you want to contribute and ask questions.
+
+### Need to Start a Discussion?
+
+If you are unsure and want to first reach out and ask about how to approach certain fix/enhancement, you are welcome to use GitHub discussions which should be enabled for all Weld repositories.  
+Alternatively, you can reach out to us via the [weld-dev mailing list](https://lists.jboss.org/archives/list/weld-dev@lists.jboss.org/).
+
+### Pull Request Standards:
+
+* Pull requests are typically sent from your fork of this repository
+* Each pull request should link to a tracking issue, ee the [section below](#issues) for more information
+* If possible and applicable, try to write an automated test
+  * In case you are uncertain how to do that, create a pull request without it and ask for help
+* While working on a pull request, you can use any amount of commits but once done, it is preferable to squash commits into a single one
+* Commit message(s) should be meaningful and if the project uses JIRA, it should start with the JIRA issue number
+  * For instance `WELD-1234 Fix the answer to universe, life and everything`
+
+### Issues
+
+Weld API uses JIRA to manage issues. All issues can be found [here](https://issues.redhat.com/projects/WELD/issues/).
+
+To create a new issue, comment on an existing issue, or assign an issue to yourself, you'll need to first [create a JIRA account](https://issues.redhat.com/).
+
+Lastly, this project is an open source project. Please act responsibly, be nice, polite and enjoy!

--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,35 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+


### PR DESCRIPTION
As part of Commonhaus foundation, all Weld's non-archived projects need to adhere to foundation's requirements which include having the following documents in the repository:
* License
* Developer Code of Origin (DCO)
* Code of Conduct
* Contributing
* Governance

This PR aims add missing files or perhaps adjust existing ones. The governance doc might come slightly later as we need to sync that with WildFly Commonhaus org, which Weld is part of and as such needs to build on their governance ideas.