### PR TITLE
Bump `jakarta.cdi-api` from 5.0.0.Alpha3 to 5.0.0.Alpha4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: monthly
+    interval: daily
   open-pull-requests-limit: 10
   target-branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
         <annotation.api.version>3.0.0</annotation.api.version>
         <atinject.api.version>2.0.1</atinject.api.version>
-        <cdi.api.version>5.0.0.Alpha3</cdi.api.version>
+        <cdi.api.version>5.0.0.Alpha4</cdi.api.version>
         <ejb.api.version>4.0.1</ejb.api.version>
         <jaxrs.api.version>4.0.0</jaxrs.api.version>
         <jpa.api.version>3.2.0</jpa.api.version>


### PR DESCRIPTION
Also change dependabot Maven check interval from monthly to daily.