### PR TITLE
Add EntityAgent support to JpaInjectionServices SPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <cdi.api.version>5.0.0.Beta1</cdi.api.version>
         <ejb.api.version>4.0.1</ejb.api.version>
         <jaxrs.api.version>4.0.0</jaxrs.api.version>
-        <jpa.api.version>3.2.0</jpa.api.version>
+        <jpa.api.version>4.0.0-M4</jpa.api.version>
         <jta.api.version>2.0.1</jta.api.version>
         <interceptor.api.version>2.2.0</interceptor.api.version>
         <servlet.api.version>6.1.0</servlet.api.version>

--- a/weld-spi/src/main/java/org/jboss/weld/injection/spi/JpaInjectionServices.java
+++ b/weld-spi/src/main/java/org/jboss/weld/injection/spi/JpaInjectionServices.java
@@ -17,8 +17,10 @@
 package org.jboss.weld.injection.spi;
 
 import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.persistence.EntityAgent;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceAgent;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceUnit;
 
@@ -60,5 +62,21 @@ public interface JpaInjectionServices extends Service {
      * @throws IllegalStateException if no suitable persistence units can be resolved
      */
     ResourceReferenceFactory<EntityManagerFactory> registerPersistenceUnitInjectionPoint(InjectionPoint injectionPoint);
+
+    /**
+     * Register a persistence agent injection point. The implementation validates the injection point. If the validation passes,
+     * an instance of {@link ResourceReferenceFactory} is returned which may be used at runtime for creating instances of the
+     * resource.
+     *
+     * @param injectionPoint the injection point metadata
+     * @return factory for obtaining {@link EntityAgent} instances
+     * @throws IllegalArgumentException if the injection point is not annotated with {@link PersistenceAgent},
+     *         if the injection point is a method that doesn't follow JavaBean conventions
+     * @throws IllegalStateException if no suitable persistence units can be resolved
+     * @since 7.0
+     */
+    default ResourceReferenceFactory<EntityAgent> registerPersistenceAgentInjectionPoint(InjectionPoint injectionPoint) {
+        throw new UnsupportedOperationException("EntityAgent injection is not supported");
+    }
 
 }

--- a/weld-spi/src/main/java/org/jboss/weld/injection/spi/helpers/ForwardingJpaInjectionServices.java
+++ b/weld-spi/src/main/java/org/jboss/weld/injection/spi/helpers/ForwardingJpaInjectionServices.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.injection.spi.helpers;
 
 import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.persistence.EntityAgent;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
@@ -46,6 +47,10 @@ public abstract class ForwardingJpaInjectionServices implements JpaInjectionServ
 
     public ResourceReferenceFactory<EntityManagerFactory> registerPersistenceUnitInjectionPoint(InjectionPoint injectionPoint) {
         return delegate().registerPersistenceUnitInjectionPoint(injectionPoint);
+    }
+
+    public ResourceReferenceFactory<EntityAgent> registerPersistenceAgentInjectionPoint(InjectionPoint injectionPoint) {
+        return delegate().registerPersistenceAgentInjectionPoint(injectionPoint);
     }
 
     @Override

--- a/weld-spi/src/test/java/org/jboss/weld/bootstrap/api/test/MockJpaServices.java
+++ b/weld-spi/src/test/java/org/jboss/weld/bootstrap/api/test/MockJpaServices.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.bootstrap.api.test;
 
 import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.persistence.EntityAgent;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
@@ -33,5 +34,10 @@ public class MockJpaServices extends MockService implements JpaInjectionServices
     @Override
     public ResourceReferenceFactory<EntityManagerFactory> registerPersistenceUnitInjectionPoint(InjectionPoint injectionPoint) {
         return new MockResourceFactory<EntityManagerFactory>();
+    }
+
+    @Override
+    public ResourceReferenceFactory<EntityAgent> registerPersistenceAgentInjectionPoint(InjectionPoint injectionPoint) {
+        return new MockResourceFactory<EntityAgent>();
     }
 }


### PR DESCRIPTION
Hey 👋🏻 🙂 

With JPA 4 there's going to be an extra injection point for entity agents: 

https://github.com/jakartaee/persistence/blob/8eaaf0b62e93f18595fcb1fea7a0f2e37ec8c388/spec/src/main/asciidoc/ch07-entitymanagers-and-persistence-contexts.adoc?plain=1#L126-L161

This PR is to get this work going 🤞🏻 🙂 