### PR TITLE
Add GitHub Release step and Dependabot for 6.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,45 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 15
   target-branch: master
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 15
   target-branch: master
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 15
+  target-branch: "6.0"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 15
+  target-branch: "6.0"
+  ignore:
+    - dependency-name: "jakarta.enterprise:jakarta.enterprise.cdi-api"
+      versions: ["[5.0,)"]
+    - dependency-name: "jakarta.interceptor:jakarta.interceptor-api"
+      versions: ["[2.3,)"]
+    - dependency-name: "jakarta.inject:jakarta.inject-api"
+      versions: ["[2.1,)"]
+    - dependency-name: "jakarta.annotation:jakarta.annotation-api"
+      versions: ["[3.1,)"]
+    - dependency-name: "jakarta.servlet:jakarta.servlet-api"
+      versions: ["[7.0,)"]
+    - dependency-name: "jakarta.persistence:jakarta.persistence-api"
+      versions: ["[3.3,)"]
+    - dependency-name: "jakarta.transaction:jakarta.transaction-api"
+      versions: ["[2.1,)"]
+    - dependency-name: "jakarta.ejb:jakarta.ejb-api"
+      versions: ["[4.1,)"]
+    - dependency-name: "jakarta.ws.rs:jakarta.ws.rs-api"
+      versions: ["[4.1,)"]
+    - dependency-name: "jakarta.validation:jakarta.validation-api"
+      versions: ["[3.2,)"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         token: ${{secrets.RELEASE_TOKEN}}
+        # Full history needed for git describe in the GitHub Release step
+        fetch-depth: 0
 
     - name: Set up JDK 17
       uses: actions/setup-java@v5
@@ -55,3 +57,19 @@ jobs:
         mvn -B release:perform -Drelease
         git push
         git push --tags
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{secrets.RELEASE_TOKEN}}
+      run: |
+        TAG=${{steps.metadata.outputs.current-version}}
+        PREV_TAG=$(git describe --abbrev=0 --tags "${TAG}^")
+        PRERELEASE_FLAG=""
+        if echo "${TAG}" | grep -qE 'Alpha|Beta|CR'; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+        gh release create "${TAG}" \
+          --generate-notes \
+          --notes-start-tag "${PREV_TAG}" \
+          --title "Weld API ${TAG}" \
+          ${PRERELEASE_FLAG}


### PR DESCRIPTION
Add GitHub Release creation during releases and Dependabot monitoring for the 6.0 branch with Jakarta EE 11 version pins.