### PR TITLE
Add GitHub Release step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,14 @@ jobs:
         metadata-file-path: '.github/project.yml'
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{secrets.RELEASE_TOKEN}}
+        # Full history needed for git describe in the GitHub Release step
+        fetch-depth: 0
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: 17
@@ -55,3 +57,19 @@ jobs:
         mvn -B release:perform -Drelease
         git push
         git push --tags
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{secrets.RELEASE_TOKEN}}
+      run: |
+        TAG=${{steps.metadata.outputs.current-version}}
+        PREV_TAG=$(git describe --abbrev=0 --tags "${TAG}^")
+        PRERELEASE_FLAG=""
+        if echo "${TAG}" | grep -qE 'Alpha|Beta|CR'; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+        gh release create "${TAG}" \
+          --generate-notes \
+          --notes-start-tag "${PREV_TAG}" \
+          --title "Weld API ${TAG}" \
+          ${PRERELEASE_FLAG}


### PR DESCRIPTION
Add GitHub Release creation during releases with auto-generated notes, prerelease detection, and upgraded action versions.